### PR TITLE
Pin requirements and document update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,14 @@ implementations and the service should not be considered production ready.
    meal, example recipes and a grocery list. Use `/compare` to obtain dummy
    pricing data from different providers.
 
+## Updating pinned dependencies
+
+Package versions in `requirements.txt` are pinned to guarantee reproducible
+installs. When a dependency such as FastAPI, Uvicorn, Pillow or the test
+framework needs an update:
+
+1. Edit `requirements.txt` and change the version numbers as required.
+2. Re-install the dependencies with `pip install -r requirements.txt`.
+3. Run `pytest` to ensure the application still functions correctly.
+
 This project is licensed under the Apache 2.0 license.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-fastapi
-uvicorn
+fastapi==0.109.2
+uvicorn==0.27.1
+pillow==10.2.0
+pytest==8.1.1


### PR DESCRIPTION
## Summary
- pin dependencies fastapi, uvicorn, pillow and pytest
- document how to update the pinned versions in README

## Testing
- `pytest -q`